### PR TITLE
Convert nix pkg to flake for better integration with mantis-ops

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,6 @@
+# NOTE this is left for backwards compatibility with current mantis-ops/master
+#      but can (and should) be removed (along with `nix/*`) once mantis-ops/darwin
+#      is merged. kthxbye
 { src    ? ./.
 , system ? builtins.currentSystem }:
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,41 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1603802751,
+        "narHash": "sha256-K3CeF3CYy7LCu0J1NnSdo77oVIkcwf0cXDAA/HFjP58=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8a1fdce8d3482b60ac13678a8eab838777b51549",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,20 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.simpleFlake rec {
-      inherit self nixpkgs;
-      systems = [ "x86_64-linux" "x86_64-darwin" ];
+    let
       name = "mantis-explorer";
+      systems = [ "x86_64-linux" "x86_64-darwin" ];
       overlay = final: prev: {
-        ${name}.defaultPackage = final.callPackage ./package.nix {};
+        ${name}.defaultPackage = final.callPackage ./package.nix { };
       };
+
+      simpleFlake = flake-utils.lib.simpleFlake
+        {
+          inherit name systems overlay self nixpkgs;
+        };
+    in
+    simpleFlake // {
+      hydraJobs = self.packages;
+      inherit overlay;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,15 @@
+{
+  description = "Mantis Explorer";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.simpleFlake rec {
+      inherit self nixpkgs;
+      systems = [ "x86_64-linux" "x86_64-darwin" ];
+      name = "mantis-explorer";
+      overlay = final: prev: {
+        ${name}.defaultPackage = final.callPackage ./package.nix {};
+      };
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -4,6 +4,8 @@ mkYarnPackage {
   src       = ./.;
 
   WEB3_PROVIDER = "/rpc/node";
+  BABEL_ENV = "development";
+  NODE_ENV = "development";
 
   doCheck    = true;
   checkPhase = "yarn test --coverage --ci";

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,20 @@
+{ mkYarnPackage }:
+
+mkYarnPackage {
+  src       = ./.;
+
+  WEB3_PROVIDER = "/rpc/node";
+
+  doCheck    = true;
+  checkPhase = "yarn test --coverage --ci";
+  distPhase  = "true";
+
+  buildPhase = ''
+    export HOME="$NIX_BUILD_TOP"
+    yarn run build
+  '';
+
+  installPhase = ''
+    mv deps/$pname/build $out
+  '';
+}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.BABEL_ENV = process.env.BABEL_ENV || 'production';
+process.env.NODE_ENV =  process.env.NODE_ENV  || 'production';
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
@@ -18,7 +18,7 @@ const path = require('path');
 const chalk = require('chalk');
 const fs = require('fs-extra');
 const webpack = require('webpack');
-const config = require('../config/webpack.config.prod');
+const config = require(`../config/webpack.config.${{development: 'dev', production: 'prod'}[process.env.NODE_ENV]}`);
 const paths = require('../config/paths');
 const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
 const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');


### PR DESCRIPTION
Notes:
- `build.js` defaults `{NODE,BABEL}_ENV` to `production` only when not already set by the environment (note that build currently fails to minify when set to `production`)
- The old `default.nix` is left in place because `mantis-ops/master` is not yet modified to use the flake