### PR TITLE
Parametise Mantis VMs

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -6,10 +6,16 @@ mkYarnPackage {
   WEB3_PROVIDER = "/rpc/node";
   BABEL_ENV = "development";
   NODE_ENV = "development";
+  MANTIS_VM = "VM_Name";
 
   doCheck    = true;
   checkPhase = "yarn test --coverage --ci";
   distPhase  = "true";
+
+  patchPhase = ''
+    substituteInPlace public/index.html --replace "{process.env.MANTIS_VM}" "$MANTIS_VM"
+    substituteInPlace src/components/layout/Header.js --replace "{process.env.MANTIS_VM}" "$MANTIS_VM"
+  '';
 
   buildPhase = ''
     export HOME="$NIX_BUILD_TOP"

--- a/public/index.html
+++ b/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>Mantis Sagano Explorer</title>
+    <title>{process.env.MANTIS_VM} DevNet Explorer</title>
   </head>
   <body id="body">
     <noscript>

--- a/src/components/layout/Header.js
+++ b/src/components/layout/Header.js
@@ -30,7 +30,7 @@ class Header extends Component {
             <div className="pure-menu">
               <ul className="pure-menu-list">
                 <li className="pure-menu-item">
-                  <a href={`${process.env.PUBLIC_URL}/`} className="pure-menu-link title"> Mantis Sagano Explorer </a>
+                  <a href={`${process.env.PUBLIC_URL}/`} className="pure-menu-link title"> {process.env.MANTIS_VM} DevNet Explorer </a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
This PR facilitates the ability to gracefully run explorer instances for multiple Mantis VMs and is utilised in a forthcoming PR in the `mantis-ops/kevm` branch.

Additionally reflects what is currently being run in production.